### PR TITLE
Feat/better templates

### DIFF
--- a/tests/transforms/template-data.test.js
+++ b/tests/transforms/template-data.test.js
@@ -2,7 +2,7 @@ import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import path from 'node:path';
 
-import { dataPath, handleTemplateFile, template } from '../../src/transforms/template-data.js';
+import { dataPath, handleTemplateFile, parseArguments, template } from '../../src/transforms/template-data.js';
 import { SissiConfig } from '../../src/sissi-config.js';
 import md from '../../src/md.js';
 
@@ -13,6 +13,12 @@ const TEST_DATA = {
     'authors': ['Joe', 'Lea'],
   },
   'theMatrix': [[1,2,3],[4,5,6],[7,8,9]],
+  date() {
+    return '12.03.2024'
+  },
+  greet(str) {
+    return 'Hello ' + str;
+  }
 }
 
 const TEST_MD = `---
@@ -31,6 +37,12 @@ const TEST_TEMPLATE = `<h1>{{ title }}</h1>
 const TEST_TEMPLATE_EXPECTED = `<h1>This is a title</h1>
 <p>Blog article by Lea</p>
 `
+
+const TEST_TEMPLATE_2 = `{{ date }}`
+const TEST_TEMPLATE_EXPECTED_2 = '12.03.2024';
+
+const TEST_TEMPLATE_3 = `{{ greet(meta.authors[1]) }}`
+const TEST_TEMPLATE_EXPECTED_3 = 'Hello Lea';
 
 describe('dataPath tests', () => {
 
@@ -57,6 +69,17 @@ describe('dataPath tests', () => {
     assert.throws(() => dataPath('object.[1]'));
     assert.throws(() => dataPath('object..[1]'));
   });
+});
+
+describe('parseArguments function', () => {
+  it('should parse argument lists', () => {
+    assert.deepEqual(parseArguments('"DE"', {}), ["DE"]);
+    assert.deepEqual(parseArguments('12.3, "DE"', {}), [12.3, "DE"]);
+  });
+
+  it('should support data path arguments', () => {
+    assert.deepEqual(parseArguments('meta.author, 12', {meta:{author:'Lea'}}), ['Lea', 12]);
+  });
 
 });
 
@@ -64,7 +87,20 @@ describe('template function', () => {
   it('should insert data into the placeholders wrapped in double curly brackets', () => {
     assert.equal(template(TEST_TEMPLATE)(TEST_DATA), TEST_TEMPLATE_EXPECTED);
   });
-})
+
+  it('should be able to invoke functions', () => {
+    assert.equal(template(TEST_TEMPLATE_2)(TEST_DATA), TEST_TEMPLATE_EXPECTED_2);
+    assert.equal(template(TEST_TEMPLATE_3)(TEST_DATA), TEST_TEMPLATE_EXPECTED_3);
+  });
+
+  it('should be able to apply a filter', () => {
+    const filters = new Map();
+    filters.set('shout', (str) => (str||'').toUpperCase());
+    const result = template('{{greeting | shout }}')({greeting: "Hello"}, filters);
+    
+    assert.equal(result, "HELLO");
+  })
+});
 
 describe('handleTemplateFile function', () => {
   it('should work with the default markdown plugin', async () => {

--- a/tests/transforms/template-data.test.js
+++ b/tests/transforms/template-data.test.js
@@ -99,7 +99,17 @@ describe('template function', () => {
     const result = template('{{greeting | shout }}')({greeting: "Hello"}, filters);
     
     assert.equal(result, "HELLO");
-  })
+  });
+
+  it('should be able to apply a filter with additional parameters', () => {
+    const data = { greeting: 'Hello Lea'}
+    const filters = new Map();
+    filters.set('piratify', (str, prefix = 'Yo-ho-ho', suffix = 'yarrr') => `${prefix}! ${str}, ${suffix}!`);
+
+    assert.equal(template('{{ greeting | piratify }}')(data, filters), 'Yo-ho-ho! Hello Lea, yarrr!');
+    assert.equal(template('{{ greeting | piratify: "AYE" }}')(data, filters), 'AYE! Hello Lea, yarrr!');
+    assert.equal(template('{{ greeting | piratify: "Ahoy", "matey" }}')(data, filters), 'Ahoy! Hello Lea, matey!');
+  });
 });
 
 describe('handleTemplateFile function', () => {


### PR DESCRIPTION
- support of functions inside template data: if a referenced template variable is a function, it is invoked without parameters. Additionally, it is possible to specify an argument list, see [tests](https://github.com/learosema/sissi/compare/main...feat/better-templates#diff-03120965e0493d857a1a6137dac6df211a2a1fe109ce47f468e654f61734c745R41)
- support of filters, eg. something like `{{ greeting | piratify: "Ahoy", "matey" }}` becomes `'Ahoy! Hello Lea, matey!'`