### PR TITLE
Feat/improve dependency graph

### DIFF
--- a/src/dependency-graph.js
+++ b/src/dependency-graph.js
@@ -5,9 +5,9 @@ import path from 'node:path';
  * Gets a Record of dependencies per file
  * @param {*} inputFilePaths 
  * @param {*} resolver 
- * @returns {Promise<Record<string, string[]>>} record of paths. As soon as the path in key changes, the array of files in the value need to be rebuilt.
+ * @returns {Promise<Record<string, string[]>>} a map documenting: the file key is included by the array of files in the value
  */
-export async function getDependencyGraph(inputRootDir, inputFilePaths, resolver) {
+export async function getDependencyMap(inputRootDir, inputFilePaths, resolver) {
   const deps = {};
   for (const inputFilePath of inputFilePaths) {
     if (/\.(md|css|html?)$/.test(inputFilePath)) {
@@ -27,4 +27,30 @@ export async function getDependencyGraph(inputRootDir, inputFilePaths, resolver)
     }
   }
   return deps;
+}
+
+/**
+ * Recursively walk through the dependency map for a specific file
+ * @param {*} map the dependency map
+ * @param {*} file the file in question
+ * @param {number} depth number of iterations
+ * @returns {string[]} array of files 
+ */
+export function walkDependencyMap(map, file, depth = 10) {
+  const deps = map[file];
+  const childDeps = [];
+  if (! deps) {
+    return [];
+  }
+  let result = new Map(Array.from(deps.map(x => [x, true])));
+  for (const dep of deps) {
+    result.set(dep, true);
+    if (depth > 0) {
+      childDeps.push(...walkDependencyMap(map, dep, depth - 1));
+    }
+  }
+  for (const childDep of childDeps) {
+    result.set(childDep, true);
+  }
+  return Array.from(result.keys());
 }

--- a/tests/dependency-graph.test.js
+++ b/tests/dependency-graph.test.js
@@ -49,5 +49,50 @@ describe('Dependency Graph', () => {
     });
   });
 
+  it('should handle css dependencies correctly', async () => {
+    const files = {
+      'styles.css': 'import "./_reset.css";',
+      '_reset.css': '*{box-sizing:border-box;margin:0}\n'
+    };
+
+    const resolve = setupVFS(files);
+    
+    const dependencies = await getDependencyGraph('', Object.keys(files), resolve);
+
+    assert.deepEqual(dependencies, {
+      '_reset.css': ['styles.css'],
+    });
+  });
+
+  it('should handle html dependencies correctly', async () => {
+    const files = {
+      'index.html': '<html-include src="top.html">',
+      '_includes/top.html': '<header>header</header>\n'
+    };
+
+    const resolve = setupVFS(files);
+    
+    const dependencies = await getDependencyGraph('', Object.keys(files), resolve);
+
+    assert.deepEqual(dependencies, {
+      '_includes/top.html': ['index.html'],
+    });
+  });
+
+  it('should handle html includes in markdown correctly', async () => {
+    const files = {
+      'index.md': '<html-include src="top.html">',
+      '_includes/top.html': '<header>header</header>\n'
+    };
+
+    const resolve = setupVFS(files);
+    
+    const dependencies = await getDependencyGraph('', Object.keys(files), resolve);
+
+    assert.deepEqual(dependencies, {
+      '_includes/top.html': ['index.md'],
+    });
+  });
+
 
 });

--- a/tests/dependency-graph.test.js
+++ b/tests/dependency-graph.test.js
@@ -1,9 +1,9 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import path from 'node:path';
-import { getDependencyGraph } from '../src/dependency-graph.js';
+import { getDependencyMap, walkDependencyMap } from '../src/dependency-graph.js';
 
-describe('Dependency Graph', () => {
+describe('Dependency Map', () => {
 
   const withFrontmatter = (str, data) => `---json\n${JSON.stringify(data)}\n---\n${str}`
 
@@ -18,81 +18,116 @@ describe('Dependency Graph', () => {
     }
   }
 
-  it('should return a records, mapping each dependants per file', async () => {
-    const files = {
-      'index.html': withFrontmatter('# {{ title }}', {title: 'Hello', layout: 'base.html'}),
-      '_layouts/base.html': '<body>{{ content | safe }}</body>',
-    };
-
-    const resolve = setupVFS(files);
-    
-    const dependencies = await getDependencyGraph('', Object.keys(files), resolve);
-
-    assert.deepEqual(dependencies, {
-      '_layouts/base.html': ['index.html'],
+  describe('getDependencyMap', () => {
+    it('should return a records, mapping each dependants per file', async () => {
+      const files = {
+        'index.html': withFrontmatter('# {{ title }}', {title: 'Hello', layout: 'base.html'}),
+        '_layouts/base.html': '<body>{{ content | safe }}</body>',
+      };
+  
+      const resolve = setupVFS(files);
+      
+      const dependencies = await getDependencyMap('', Object.keys(files), resolve);
+  
+      assert.deepEqual(dependencies, {
+        '_layouts/base.html': ['index.html'],
+      });
+    });
+  
+    it('should handle layouts depending on other layouts correctly', async () => {
+      const files = {
+        'index.html': withFrontmatter('# {{ title }}', {title: 'Hello', layout: 'base.html'}),
+        '_layouts/base.html': '<body>{{ content | safe }}</body>',
+        '_layouts/article.html': withFrontmatter(
+          '<article><h1>{{ title }}</h1>{{ content | safe }}</article>', 
+          { layout: 'base.html' }
+        )
+      };
+  
+      const resolve = setupVFS(files);
+      
+      const dependencies = await getDependencyMap('', Object.keys(files), resolve);
+  
+      assert.deepEqual(dependencies, {
+        '_layouts/base.html': ['index.html', '_layouts/article.html'],
+      });
+    });
+  
+    it('should handle css dependencies correctly', async () => {
+      const files = {
+        'styles.css': 'import "./_reset.css";',
+        '_reset.css': '*{box-sizing:border-box;margin:0}\n'
+      };
+  
+      const resolve = setupVFS(files);
+      
+      const dependencies = await getDependencyMap('', Object.keys(files), resolve);
+  
+      assert.deepEqual(dependencies, {
+        '_reset.css': ['styles.css'],
+      });
+    });
+  
+    it('should handle html dependencies correctly', async () => {
+      const files = {
+        'index.html': '<html-include src="top.html">',
+        '_includes/top.html': '<header>header</header>\n'
+      };
+  
+      const resolve = setupVFS(files);
+      
+      const dependencies = await getDependencyMap('', Object.keys(files), resolve);
+  
+      assert.deepEqual(dependencies, {
+        '_includes/top.html': ['index.html'],
+      });
+    });
+  
+    it('should handle html includes in markdown correctly', async () => {
+      const files = {
+        'index.md': '<html-include src="top.html">',
+        '_includes/top.html': '<header>\nheader\n<html-include src="nav.html">\n</header>\n',
+        '_includes/nav.html': '<nav></nav>'
+      };
+  
+      const resolve = setupVFS(files);
+      
+      const dependencies = await getDependencyMap('', Object.keys(files), resolve);
+  
+      assert.deepEqual(dependencies, {
+        '_includes/top.html': ['index.md'],
+        '_includes/nav.html': ['_includes/top.html']
+      });
     });
   });
 
-  it('should handle layouts depending on other layouts correctly', async () => {
-    const files = {
-      'index.html': withFrontmatter('# {{ title }}', {title: 'Hello', layout: 'base.html'}),
-      '_layouts/base.html': '<body>{{ content | safe }}</body>',
-      '_layouts/article.html': withFrontmatter('<article><h1>{{ title }}</h1>{{ content | safe }}</article>', {layout: 'base.html'})
-    };
 
-    const resolve = setupVFS(files);
-    
-    const dependencies = await getDependencyGraph('', Object.keys(files), resolve);
+  describe('walkDependencyMap', () => {
 
-    assert.deepEqual(dependencies, {
-      '_layouts/base.html': ['index.html', '_layouts/article.html'],
+    it('should handle waterfall includes', () => {
+      const dependencyMap  = {
+        '_includes/top.html': ['index.md'],
+        '_includes/nav.html': ['_includes/top.html']
+      };
+      
+      const result = walkDependencyMap(dependencyMap, '_includes/nav.html');
+      result.sort(); // order doesn't matter, we sort it for a deterministic assertion
+
+      assert.deepEqual(result, ['_includes/top.html', 'index.md']);
     });
-  });
 
-  it('should handle css dependencies correctly', async () => {
-    const files = {
-      'styles.css': 'import "./_reset.css";',
-      '_reset.css': '*{box-sizing:border-box;margin:0}\n'
-    };
+    it('should handle circular dependencies', () => {
+      const dependencyMap = {
+        'b.html': ['a.html', 'c.html'],
+        'c.html': ['b.html'],
+      };
 
-    const resolve = setupVFS(files);
-    
-    const dependencies = await getDependencyGraph('', Object.keys(files), resolve);
+      const result = walkDependencyMap(dependencyMap, 'c.html');
+      result.sort(); // order doesn't matter, we sort it for a deterministic assertion
 
-    assert.deepEqual(dependencies, {
-      '_reset.css': ['styles.css'],
+      assert.deepEqual(result, ['a.html', 'b.html', 'c.html']);      
     });
+
   });
-
-  it('should handle html dependencies correctly', async () => {
-    const files = {
-      'index.html': '<html-include src="top.html">',
-      '_includes/top.html': '<header>header</header>\n'
-    };
-
-    const resolve = setupVFS(files);
-    
-    const dependencies = await getDependencyGraph('', Object.keys(files), resolve);
-
-    assert.deepEqual(dependencies, {
-      '_includes/top.html': ['index.html'],
-    });
-  });
-
-  it('should handle html includes in markdown correctly', async () => {
-    const files = {
-      'index.md': '<html-include src="top.html">',
-      '_includes/top.html': '<header>header</header>\n'
-    };
-
-    const resolve = setupVFS(files);
-    
-    const dependencies = await getDependencyGraph('', Object.keys(files), resolve);
-
-    assert.deepEqual(dependencies, {
-      '_includes/top.html': ['index.md'],
-    });
-  });
-
 
 });

--- a/tests/sissi.test.js
+++ b/tests/sissi.test.js
@@ -10,7 +10,6 @@ describe('sissi', () => {
 
   it('should successfully build a smallsite', async () => {
 
-
     const config = new SissiConfig({
       dir: {
         input: 'tests/fixtures/smallsite',


### PR DESCRIPTION
- Check which files include what
- recursively walk through the dependency map
- circular dependencies are handled just fine without crashing